### PR TITLE
Fix "Stop Simulation" button on windows

### DIFF
--- a/emu/emu.c
+++ b/emu/emu.c
@@ -18,9 +18,18 @@
 // TODO: illegal instruction warnings
 
 static bool stop_simulation(struct JDH8 *state) {
-    struct pollfd pfds = { .fd = fileno(stdin), .events = POLLIN };
-
-    if (poll(&pfds, 1, 0) > 0 && (pfds.events & POLLIN)) {
+	#if defined(WIN32) || defined(_WIN32)
+		// Should Fix enter key not working on Windows.
+		// Key code from https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
+		// I wish Microsoft would rewrite Windows from scratch to be POSIX compliant and... better for technical people
+		
+		if (GetKeyState(VK_RETURN) & 0x8000)
+	#else
+		struct pollfd pfds = { .fd = fileno(stdin), .events = POLLIN };
+		
+		if (poll(&pfds, 1, 0) > 0 && (pfds.events & POLLIN)) 
+	#endif
+	{
         char c;
         return read(fileno(stdin), &c, 1) > 0;
     }

--- a/emu/win/win.c
+++ b/emu/win/win.c
@@ -28,46 +28,6 @@ size_t strlcpy(char *restrict dst, const char *restrict src, size_t dstsize) {
     return(offset);
 }
 
-// from https://narkive.com/oLyNbGSV
-int poll(struct pollfd *p, int num, int timeout) {
-	struct timeval tv;
-	fd_set read, write, except;
-	int i, n, ret;
-
-	FD_ZERO(&read);
-	FD_ZERO(&write);
-	FD_ZERO(&except);
-
-	n = -1;
-	for (i = 0; i < num; i++) {
-		if (p[i].fd < 0) continue;
-		if (p[i].events & POLLIN) FD_SET(p[i].fd, &read);
-		if (p[i].events & POLLOUT) FD_SET(p[i].fd, &write);
-		if (p[i].events & POLLERR) FD_SET(p[i].fd, &except);
-		if (p[i].fd > n) n = p[i].fd;
-	}
-
-	if (n == -1) {
-        return 0;
-    }
-
-	if (timeout < 0) {
-		ret = select(n + 1, &read, &write, &except, NULL);
-    } else {
-		tv.tv_sec = timeout / 1000;
-		tv.tv_usec = 1000 * (timeout % 1000);
-		ret = select(n + 1, &read, &write, &except, &tv);
-	}
-
-	for (i = 0; ret >= 0 && i < num; i++) {
-		p[i].revents = 0;
-		if (FD_ISSET(p[i].fd, &read)) p[i].revents |= POLLIN;
-		if (FD_ISSET(p[i].fd, &write)) p[i].revents |= POLLOUT;
-		if (FD_ISSET(p[i].fd, &except)) p[i].revents |= POLLERR;
-	}
-
-	return ret;
-}
 // from https://github.com/Arryboom/fmemopen_windows/blob/master/libfmemopen.c
 
 FILE *fmemopen(void *buf, size_t len, const char *type) {

--- a/emu/win/win.h
+++ b/emu/win/win.h
@@ -10,20 +10,6 @@
 
 size_t strlcpy(char *restrict dst, const char *restrict src, size_t dstsize);
 
-#define POLLIN 0x0001
-#define POLLPRI 0x0002 /* not used */
-#define POLLOUT 0x0004
-#define POLLERR 0x0008
-#define POLLHUP 0x0010 /* not used */
-#define POLLNVAL 0x0020 /* not used */
-
-struct pollfd {
-	int fd;
-	int events; /* in param: what to poll for */
-	int revents; /* out param: what events occured */
-};
-int poll (struct pollfd *p, int num, int timeout);
-
 FILE *fmemopen(void *buf, size_t len, const char *type);
 
 char* readline(char* prompt);


### PR DESCRIPTION
NOTE :: The removal of the function here removes the need for a certain linkage that I removed in my other PR around this time, so that should be merged alongside this (or just remove `-lws_32` as I think it's called)